### PR TITLE
Improve chess board sizing and timer reset

### DIFF
--- a/src/screens/ChessBoard.js
+++ b/src/screens/ChessBoard.js
@@ -1,11 +1,11 @@
 import {Observer} from 'mobx-react';
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import {
   StyleSheet,
   View,
-  Dimensions,
   TouchableOpacity,
   Text,
+  useWindowDimensions,
 } from 'react-native';
 import GameStore from '../store/GameStore';
 
@@ -25,9 +25,12 @@ const colMap = {
 const rowMap = {1: 8, 2: 7, 3: 6, 4: 5, 5: 4, 6: 3, 7: 2, 8: 1};
 
 // const KEY = 'C6';
+const HEADER_OFFSET = 100;
+
 const ChessBoard = ({boardColor, squareColor, onPress, showCords}) => {
-  const {width} = Dimensions.get('window');
-  const squareSize = width / BOARD_SIZE;
+  const {width, height} = useWindowDimensions();
+  const boardSize = Math.min(width, height - HEADER_OFFSET);
+  const squareSize = boardSize / BOARD_SIZE;
 
   const renderSquare = (row, col) => {
     const isDarkSquare = (row + col) % 2 === 1;
@@ -77,7 +80,11 @@ const ChessBoard = ({boardColor, squareColor, onPress, showCords}) => {
     rows.push(renderRow(row));
   }
 
-  return <View style={[styles.board, {width}]}>{rows}</View>;
+  return (
+    <View style={[styles.board, {width: boardSize, height: boardSize}]}>
+      {rows}
+    </View>
+  );
 };
 
 const styles = StyleSheet.create({

--- a/src/screens/Game.js
+++ b/src/screens/Game.js
@@ -25,6 +25,7 @@ const Game = () => {
 
   useEffect(() => {
     randomGenrator();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const randomGenrator = () => {

--- a/src/screens/components/Counter.js
+++ b/src/screens/components/Counter.js
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react';
-import {View, Text, StyleSheet, Vibration} from 'react-native';
+import {View, Vibration} from 'react-native';
 import {Observer} from 'mobx-react';
 import GameStore from '../../store/GameStore';
 import ThemeStore from '../../store/ThemeStore';
@@ -26,7 +26,11 @@ const Counter = () => {
       {() => (
         <View>
           <Progress.Bar
-            progress={GameStore.counter / GameStore.selectedGameTime}
+            progress={
+              GameStore.selectedGameTime > 0
+                ? GameStore.counter / GameStore.selectedGameTime
+                : 0
+            }
             width={AppStore.width}
             borderColor={ThemeStore.lightColor}
             color={ThemeStore.darkColor}
@@ -37,8 +41,3 @@ const Counter = () => {
   );
 };
 export default Counter;
-
-const styles = StyleSheet.create({
-  text: {color: ThemeStore.lightColor, fontWeight: '600'},
-  WarningText: {color: ThemeStore.darkColor, fontWeight: '600'},
-});

--- a/src/store/GameStore.js
+++ b/src/store/GameStore.js
@@ -19,12 +19,12 @@ class gameStore {
     this[value] = data;
     console.log(value, data);
   }
-  resetFiels() {
+
+  resetFields() {
     this.isWhite = true;
-    this.counter = 0;
+    this.counter = this.selectedGameTime;
     this.showGameOverModal = false;
     this.showGameTypeModal = false;
-    this.selectedGameTime = 0;
     this.currentScore = 0;
     this.totalScore = 0;
     this.gamePlayedTime = 0;


### PR DESCRIPTION
## Summary
- Prevent divide-by-zero in Counter by guarding against missing game time
- Rename `resetFields` and reset counter to selected game time
- Recompute chessboard size on orientation changes and constrain height

## Testing
- `npm run lint`
- `npm test` *(fails: Jest encountered an unexpected token in PNG asset)*

------
https://chatgpt.com/codex/tasks/task_e_68b143ba1970832593eb154e3bc8fc43